### PR TITLE
docs: Sorted the list of CI provider names

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,58 +19,58 @@ const inCI = ciDetect()
 Returns one of the following strings, or `false` if none match, by looking
 at the appropriate environment variables.
 
-* `'gerrit'` Gerrit
-* `'gitlab'` GitLab
-* `'circleci'` Circle-CI
-* `'semaphore'` Semaphore
-* `'drone'` Drone
-* `'github-actions'` GitHub Actions
-* `'tddium'` TDDium
-* `'jenkins'` Jenkins
-* `'bamboo'` Bamboo
-* `'gocd'` GoCD
-* `'wercker'` Oracle Wercker
-* `'woodpecker'` Woodpecker CI
-* `'netlify'` Netlify
-* `'now-github'` Zeit.co's Now for GitHub deployment service
-* `'now-bitbucket'` Zeit.co's Now for BitBucket deployment service
-* `'now-gitlab'` Zeit.co's Now for GitLab deployment service
-* `'now'` Zeit.co's Now service, but not GitHub/BitBucket/GitLab
+* Anything that sets the `CI_NAME` environment variable will return the
+  value as the result.  (This is how CodeShip is detected.)
+* `'aws-codebuild'` AWS CodeBuild
 * `'azure-pipelines'` Azure Pipelines
+* `'bamboo'` Bamboo
 * `'bitbucket-pipelines'` Bitbucket Pipelines
 * `'bitrise'` Bitrise
 * `'buddy'` Buddy
+* `'builder'` Google Cloud Builder - This one is a bit weird.  It doesn't
+  really set anything that can be reliably detected except
+  `BUILDER_OUTPUT`, so it can get false positives pretty easily.
 * `'buildkite'` Buildkite
+* `'circleci'` Circle-CI
 * `'cirrus'` Cirrus CI
+* `'codeship'` CodeShip
+* `'custom'` anything else that sets `CI` environment variable to either
+  `'1'` or `'true'`.
+* `'drone'` Drone
 * `'dsari'` dsari CI
-* `'screwdriver'` Screwdriver CI
-* `'strider'` Strider CI
-* `'taskcluster'` Mozilla Taskcluster
+* `'gerrit'` Gerrit
+* `'github-actions'` GitHub Actions
+* `'gitlab'` GitLab
+* `'gocd'` GoCD
+* `'heroku'` Heroku
 * `'hudson'` Hudson CI
+* `'jenkins'` Jenkins
 * `'magnum'` Magnum CI
+* `'netlify'` Netlify
 * `'nevercode'` Nevercode
+* `'now'` Zeit.co's Now service, but not GitHub/BitBucket/GitLab
+* `'now-bitbucket'` Zeit.co's Now for BitBucket deployment service
+* `'now-github'` Zeit.co's Now for GitHub deployment service
+* `'now-gitlab'` Zeit.co's Now for GitLab deployment service
 * `'render'` Render CI
 * `'sail'` Sail CI
+* `'screwdriver'` Screwdriver CI
+* `'semaphore'` Semaphore
 * `'shippable'` Shippable
-* `'heroku'` Heroku
-* `'codeship'` CodeShip
+* `'strider'` Strider CI
+* `'taskcluster'` Mozilla Taskcluster
+* `'tddium'` TDDium
 * `'teamcity'` TeamCity
-* `'vercel'` Vercel
-* `'vercel-github'` Vercel GitHub
-* `'vercel-gitlab'` Vercel Gitlab
-* `'vercel-bitbucket'` Vercel Bitbucket
-* Anything that sets the `CI_NAME` environment variable will return the
-  value as the result.  (This is how CodeShip is detected.)
 * `'travis-ci'` Travis-CI - A few other CI systems set `TRAVIS=1` in the
   environment, because devs use that to indicate "test mode", so this one
   can get some false positives, and is tested later in the process to
   minimize this effect.
-* `'aws-codebuild'` AWS CodeBuild
-* `'builder'` Google Cloud Builder - This one is a bit weird.  It doesn't
-  really set anything that can be reliably detected except
-  `BUILDER_OUTPUT`, so it can get false positives pretty easily.
-* `'custom'` anything else that sets `CI` environment variable to either
-  `'1'` or `'true'`.
+* `'vercel'` Vercel
+* `'vercel-bitbucket'` Vercel Bitbucket
+* `'vercel-github'` Vercel GitHub
+* `'vercel-gitlab'` Vercel Gitlab
+* `'wercker'` Oracle Wercker
+* `'woodpecker'` Woodpecker CI
 
 ## Caveats
 


### PR DESCRIPTION

Signed-off-by: Fredrik Skogman <kommendorkapten@github.com>

This is a documentation fix only. Sorts the list of CI name providers alphabetically. 
